### PR TITLE
Prevent filename traversal and collisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,10 @@ To upload a file using PowerShell you can use the following (may not be very rel
 ```
 
 Server can also be accessed on the browser for a classic upload UI.
+
+## File Storage Behavior
+
+The server uses the base name of the uploaded file when saving to avoid
+directory traversal attacks. If a file with the requested name already
+exists, a numerical suffix is appended (e.g. `file.txt`, `file_1.txt`,
+`file_2.txt`, ...).

--- a/simpleexfil.py
+++ b/simpleexfil.py
@@ -35,9 +35,17 @@ class ServerHandler(http.server.SimpleHTTPRequestHandler):
             headers=self.headers,
             environ={'REQUEST_METHOD': 'POST'}
         )
-        filename = form['file'].filename
+        filename = os.path.basename(form['file'].filename)
         file_data = form['file'].file.read()
-        with open(filename, 'wb') as f:
+
+        base, ext = os.path.splitext(filename)
+        target = filename
+        counter = 1
+        while os.path.exists(target):
+            target = f"{base}_{counter}{ext}"
+            counter += 1
+
+        with open(target, 'wb') as f:
             f.write(file_data)
 
         self.send_response(200)


### PR DESCRIPTION
## Summary
- sanitize uploaded file path using `os.path.basename`
- add logic to append numeric suffix when a file name is already present
- document how file storage works in the README

## Testing
- `python -m py_compile simpleexfil.py`

------
https://chatgpt.com/codex/tasks/task_e_68406d07b7c883319931270499225e73