### PR TITLE
Refactor simpleexfil server to avoid cgi

### DIFF
--- a/simpleexfil.py
+++ b/simpleexfil.py
@@ -1,7 +1,9 @@
 import http.server
 import socketserver
 import os
-import cgi
+from email import message_from_binary_file
+from email.policy import default
+from io import BytesIO
 import sys
 
 DEFAULT_PORT = 8000
@@ -30,15 +32,25 @@ class ServerHandler(http.server.SimpleHTTPRequestHandler):
         self.wfile.write(html.encode('utf-8'))
 
     def do_POST(self):
-        form = cgi.FieldStorage(
-            fp=self.rfile,
-            headers=self.headers,
-            environ={'REQUEST_METHOD': 'POST'}
-        )
-        filename = form['file'].filename
-        file_data = form['file'].file.read()
-        with open(filename, 'wb') as f:
-            f.write(file_data)
+        content_length = int(self.headers.get('Content-Length', 0))
+        body = self.rfile.read(content_length)
+        ct = self.headers.get('Content-Type', '')
+
+        msg_bytes = b'Content-Type: ' + ct.encode() + b"\r\n\r\n" + body
+        msg = message_from_binary_file(BytesIO(msg_bytes), policy=default)
+
+        filename = None
+        file_data = None
+        for part in msg.walk():
+            if part.get_content_disposition() == 'form-data':
+                if part.get_param('name', header='Content-Disposition') == 'file':
+                    filename = part.get_filename()
+                    file_data = part.get_payload(decode=True)
+                    break
+
+        if filename and file_data is not None:
+            with open(filename, 'wb') as f:
+                f.write(file_data)
 
         self.send_response(200)
         self.send_header('Content-type', 'text/html')


### PR DESCRIPTION
## Summary
- switch to `email.message_from_binary_file` to parse uploads
- refactor POST handler accordingly

## Testing
- `python -m py_compile simpleexfil.py`
- `curl -F "file=@testfile.txt" http://127.0.0.1:8001`

------
https://chatgpt.com/codex/tasks/task_e_68406d0fcb608331b036024b6591bc7f