### PR TITLE
Add drag-and-drop web UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,10 @@ To upload a file using PowerShell you can use the following (may not be very rel
 ```
 
 Server can also be accessed on the browser for a classic upload UI.
+
+### Enhanced Web UI
+
+This repository now includes a drag-and-drop interface. After starting the
+server, open your browser and navigate to `http://127.0.0.1:8000/` to access the
+new UI. Drop a file onto the highlighted area or click to choose a file and it
+will be uploaded automatically.

--- a/simpleexfil.py
+++ b/simpleexfil.py
@@ -11,23 +11,9 @@ port = int(sys.argv[1]) if len(sys.argv) > 1 else DEFAULT_PORT
 class ServerHandler(http.server.SimpleHTTPRequestHandler):
 
     def do_GET(self):
-        html = '''
-        <html>
-        <head>
-        <title>Upload File</title>
-        </head>
-        <body>
-        <form enctype="multipart/form-data" method="post">
-        <input name="file" type="file"/>
-        <input type="submit" value="Upload"/>
-        </form>
-        </body>
-        </html>
-        '''
-        self.send_response(200)
-        self.send_header('Content-type', 'text/html')
-        self.end_headers()
-        self.wfile.write(html.encode('utf-8'))
+        if self.path in ('/', '/index.html'):
+            self.path = '/static/index.html'
+        return http.server.SimpleHTTPRequestHandler.do_GET(self)
 
     def do_POST(self):
         form = cgi.FieldStorage(

--- a/static/index.html
+++ b/static/index.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Upload File - Drag and Drop</title>
+  <style>
+    body { font-family: Arial, sans-serif; padding: 20px; }
+    #dropzone {
+      border: 2px dashed #ccc;
+      padding: 20px;
+      text-align: center;
+      color: #666;
+      cursor: pointer;
+    }
+    #dropzone.hover {
+      border-color: #000;
+    }
+  </style>
+</head>
+<body>
+<h2>Upload File</h2>
+<div id="dropzone">Drag and drop a file here or click to select</div>
+<input type="file" id="fileinput" style="display:none" />
+<script>
+const dropzone = document.getElementById('dropzone');
+const fileinput = document.getElementById('fileinput');
+
+dropzone.addEventListener('click', () => fileinput.click());
+
+dropzone.addEventListener('dragover', (ev) => {
+  ev.preventDefault();
+  dropzone.classList.add('hover');
+});
+
+dropzone.addEventListener('dragleave', () => {
+  dropzone.classList.remove('hover');
+});
+
+dropzone.addEventListener('drop', (ev) => {
+  ev.preventDefault();
+  dropzone.classList.remove('hover');
+  if (ev.dataTransfer.files.length) {
+    upload(ev.dataTransfer.files[0]);
+  }
+});
+
+fileinput.addEventListener('change', () => {
+  if (fileinput.files.length) {
+    upload(fileinput.files[0]);
+  }
+});
+
+function upload(file) {
+  const formData = new FormData();
+  formData.append('file', file);
+  fetch('/', { method: 'POST', body: formData })
+    .then(resp => resp.text())
+    .then(text => alert(text))
+    .catch(err => alert('Upload failed'));
+}
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a static drag-and-drop upload page
- serve static files from `/static/index.html`
- update README with instructions on accessing the enhanced UI

## Testing
- `python3 -m py_compile simpleexfil.py`

------
https://chatgpt.com/codex/tasks/task_e_68406d13f18483318bf7841e17d38a5c