### PR TITLE
Add configurable upload directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,14 @@ SimpleExfil lets you exfiltrate your files. This server accepts and stores files
 
 ## Usage
 
-Start the server by specifying the desired port as an argument. If no port is specified, it defaults to 8000.
+Start the server by specifying the desired port as an argument. If no port is specified, it defaults to 8000. You can optionally specify the directory where uploaded files will be stored. If omitted, the server uses the current directory or the path provided in the `UPLOAD_DIR` environment variable.
 
 ```
-python simpleexfil.py 8000
+python simpleexfil.py [PORT] [UPLOAD_DIR]
 ```
+
+Alternatively, set the `UPLOAD_DIR` environment variable to control the
+destination folder without passing it as an argument.
 
 To upload a file, use `curl` from the command line, PowerShell, or any suitable HTTP client. Example for uploading `example.txt`:
 

--- a/simpleexfil.py
+++ b/simpleexfil.py
@@ -8,6 +8,14 @@ DEFAULT_PORT = 8000
 
 port = int(sys.argv[1]) if len(sys.argv) > 1 else DEFAULT_PORT
 
+# Determine directory for uploaded files
+upload_dir = os.environ.get("UPLOAD_DIR", ".")
+if len(sys.argv) > 2:
+    upload_dir = sys.argv[2]
+
+# Ensure the directory exists
+os.makedirs(upload_dir, exist_ok=True)
+
 class ServerHandler(http.server.SimpleHTTPRequestHandler):
 
     def do_GET(self):
@@ -37,7 +45,8 @@ class ServerHandler(http.server.SimpleHTTPRequestHandler):
         )
         filename = form['file'].filename
         file_data = form['file'].file.read()
-        with open(filename, 'wb') as f:
+        target_path = os.path.join(upload_dir, filename)
+        with open(target_path, 'wb') as f:
             f.write(file_data)
 
         self.send_response(200)


### PR DESCRIPTION
## Summary
- allow specifying upload directory via second argument or UPLOAD_DIR env var
- create upload directory automatically
- document new usage options

## Testing
- `python -m py_compile simpleexfil.py`

------
https://chatgpt.com/codex/tasks/task_e_68406d256c648331908686ffd7489c6e